### PR TITLE
Changed "deftype" to camel cased "defType"

### DIFF
--- a/solr.go
+++ b/solr.go
@@ -129,7 +129,7 @@ func (q *Query) String() string {
 	}
 
 	if q.DefType != "" {
-		s = append(s, fmt.Sprintf("deftype=%s", q.DefType))
+		s = append(s, fmt.Sprintf("defType=%s", q.DefType))
 	}
 
 	if q.Debug {


### PR DESCRIPTION
I had some troubles using DefType and saw that it is set to all lowercase "deftype". I've made a change so that it is camel cased, which appears to work as expected.
