### PR TITLE
Allow custom URLs

### DIFF
--- a/solr.go
+++ b/solr.go
@@ -303,7 +303,7 @@ func BytesToJSON(b *[]byte) (*interface{}, error) {
 	err := json.Unmarshal(*b, &container)
 
 	if err != nil {
-		return nil, fmt.Errorf("Response decode error")
+		return nil, err
 	}
 
 	return &container, nil
@@ -316,7 +316,7 @@ func BytesToJSON(b *[]byte) (*interface{}, error) {
 func JSONToBytes(m map[string]interface{}) (*[]byte, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to encode JSON")
+		return nil, err
 	}
 
 	return &b, nil
@@ -407,12 +407,12 @@ func BuildResponse(j *interface{}) (*SelectResponse, error) {
 func SelectResponseFromHTTPResponse(b []byte) (*SelectResponse, error) {
 	j, err := BytesToJSON(&b)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to decode")
+		return nil, err
 	}
 
 	resp, err := BuildResponse(j)
 	if err != nil {
-		return nil, fmt.Errorf("Error building response")
+		return nil, err
 	}
 
 	return resp, nil
@@ -487,7 +487,7 @@ func (c *Connection) CustomSelect(q *Query, handlerName string) (*SelectResponse
 	body, err := HTTPGet(SolrSelectString(c, q.String(), handlerName))
 
 	if err != nil {
-		return nil, fmt.Errorf("Some sort of http failure") // TODO: investigate how net/http fails
+		return nil, err
 	}
 
 	r, err := SelectResponseFromHTTPResponse(body)
@@ -514,7 +514,7 @@ func (c *Connection) CustomSelectRaw(q string, handlerName string) (*SelectRespo
 	body, err := HTTPGet(SolrSelectString(c, q, handlerName))
 
 	if err != nil {
-		return nil, fmt.Errorf("Some sort of http failure") // TODO: investigate how net/http fails
+		return nil, err
 	}
 
 	r, err := SelectResponseFromHTTPResponse(body)

--- a/solr.go
+++ b/solr.go
@@ -21,9 +21,7 @@ import (
  * (and probably at some point a Solr Core name)
  */
 type Connection struct {
-	Host    string
-	Port    int
-	Core    string
+	URL     string
 	Version []int
 }
 
@@ -282,7 +280,7 @@ func EncodeURLParamMap(m *URLParamMap) string {
  * Generates a Solr query string from a connection, query string and handler name
  */
 func SolrSelectString(c *Connection, q string, handlerName string) string {
-	return fmt.Sprintf("http://%s:%d/solr/%s/%s?wt=json&%s", c.Host, c.Port, c.Core, handlerName, q)
+	return fmt.Sprintf("%s/%s?wt=json&%s", c.URL, handlerName, q)
 }
 
 /*
@@ -290,7 +288,7 @@ func SolrSelectString(c *Connection, q string, handlerName string) string {
  * if commit arg is true.
  */
 func SolrUpdateString(c *Connection, commit bool) string {
-	s := fmt.Sprintf("http://%s:%d/solr/%s/update", c.Host, c.Port, c.Core)
+	s := fmt.Sprintf("%s/update", c.URL)
 	if commit {
 		return fmt.Sprintf("%s?commit=true", s)
 	}
@@ -455,7 +453,10 @@ func chunk(s []interface{}, sz int) [][]interface{} {
 /*
  * Inits a new Connection to a Solr instance
  * Note: this doesn't actually hold a connection, its just
- *       a container for holding a hostname & port
+ *       a container for the URL.
+ * This creates a URL with the pattern http://{host}:{port}/solr/{core}
+ * If you want to create a connection with another pattern just create
+ * the struct directly i.e. conn := &Connection{myCustomURL}.
  */
 func Init(host string, port int, core string) (*Connection, error) {
 
@@ -467,7 +468,8 @@ func Init(host string, port int, core string) (*Connection, error) {
 		return nil, fmt.Errorf("Invalid port (must be 1..65535")
 	}
 
-	return &Connection{Host: host, Port: port, Core: core}, nil
+	url := fmt.Sprintf("http://%s:%d/solr/%s", host, port, core)
+	return &Connection{URL: url}, nil
 }
 
 /*

--- a/solr.go
+++ b/solr.go
@@ -202,13 +202,13 @@ func HTTPGet(httpUrl string) ([]byte, error) {
 	defer r.Body.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("GET failed (%s)", httpUrl)
+		return nil, err
 	}
 
 	// read the response and check
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Response read failed")
+		return nil, err
 	}
 
 	return body, nil
@@ -242,7 +242,7 @@ func HTTPPost(url string, headers [][]string, payload *[]byte) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf(fmt.Sprintf("POST request failed: %s", err))
+		return nil, err
 	}
 
 	// read response, check & return

--- a/solr_test.go
+++ b/solr_test.go
@@ -1,0 +1,53 @@
+package solr
+
+import (
+	"testing"
+)
+
+func TestInitOK(t *testing.T) {
+
+	c, _ := Init("localhost", 8696, "core0")
+	if c.URL != "http://localhost:8696/solr/core0" {
+		t.Fail()
+	}
+
+}
+
+func TestInitInvalidHost(t *testing.T) {
+
+	_, err := Init("", 700000, "core0")
+	if err == nil {
+		t.Fail()
+	}
+}
+
+func TestInitInvalidPort(t *testing.T) {
+
+	_, err := Init("localhost", 700000, "core0")
+	if err == nil {
+		t.Fail()
+	}
+}
+
+func TestSolrSelectString(t *testing.T) {
+	c, _ := Init("localhost", 8696, "core0")
+	q := &Query{
+		Params: URLParamMap{
+			"q": []string{"id:1"},
+		},
+	}
+	s := SolrSelectString(c, q.String(), "select")
+	if s != "http://localhost:8696/solr/core0/select?wt=json&q=id%3A1" {
+		t.Fail()
+	}
+
+}
+
+func TestSolrUpdateString(t *testing.T) {
+	c, _ := Init("localhost", 8696, "core0")
+	s := SolrUpdateString(c, true)
+	if s != "http://localhost:8696/solr/core0/update?commit=true" {
+		t.Fail()
+	}
+
+}


### PR DESCRIPTION
I had an issue with our Solr install, which had the URL http://localhost:8986/core0 rather than http://localhost:8986/solr/core0 (we were unable to change this due to dependencies elsewhere). It appears the context /solr is hardcoded. This approach instead allows any custom URL needed. The Init() function still creates the same default URL, i.e. with /solr.

I've also removed some cases where the original error has been replaced by custom error messages, making debugging more difficult, and added a few tests.